### PR TITLE
add ddl-transaction tests

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.8.1"},
+  "ecto": {:hex, :ecto, "0.9.0"},
   "esqlite": {:git, "git://github.com/mmzeeman/esqlite.git", "58e5e6ed55f45d3813bfc4bd2e966178809b390e", []},
   "poolboy": {:hex, :poolboy, "1.4.2"}}


### PR DESCRIPTION
`create table`, `drop table` and `alter table` can be rolledback